### PR TITLE
Separate broadcast messages with a null byte

### DIFF
--- a/raspberry-dataserver/hevserver.py
+++ b/raspberry-dataserver/hevserver.py
@@ -181,7 +181,7 @@ class HEVServer(object):
                 logging.debug(f"Send: {json.dumps(broadcast_packet,indent=4)}")
 
             try:
-                writer.write(json.dumps(broadcast_packet).encode())
+                writer.write(json.dumps(broadcast_packet).encode() + b"\0")
                 await writer.drain()
             except (ConnectionResetError, BrokenPipeError):
                 # Connection lost, stop trying to broadcast and free up socket

--- a/raspberry-dataserver/hevserver.py
+++ b/raspberry-dataserver/hevserver.py
@@ -128,22 +128,16 @@ class HEVServer(object):
                     raise HEVPacketError(f"Alarm could not be removed. May have been removed already. {e}")
             else:
                 raise HEVPacketError(f"Invalid request type")
-
-            packet = json.dumps(payload).encode()
-
-            # send reply and close connection
-            writer.write(packet)
-            await writer.drain()
-            writer.close()
-
         except (NameError, KeyError, HEVPacketError) as e:
             # invalid request: reject immediately
             logging.warning(f"Invalid packet: {e}")
             payload = {"type": "nack"}
-            packet = json.dumps(payload).encode()
-            writer.write(packet)
-            await writer.drain()
-            writer.close()
+
+        # send reply and close connection
+        packet = json.dumps(payload).encode()
+        writer.write(packet)
+        await writer.drain()
+        writer.close()
 
     async def handle_broadcast(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         # log address


### PR DESCRIPTION
Currently hev-display has an issue where sometimes multiple messages get read at the same time (and to a lesser extent, incomplete messages). This causes it to fail to parse the data, for example when the buffer contains:

`"{\"type\": \"broadcast\", \"sensors\": {\"version\": 161, \"timestamp\": 80.69999999999999, \"fsm_state\": \"IDLE\", \"pressure_air_supply\": 0, \"pressure_air_regulated\": 0, \"pressure_o2_supply\": 0, \"pressure_o2_regulated\": 0, \"pressure_buffer\": 19.706918, \"pressure_inhale\": 276.754225, \"pressure_patient\": 0, \"temperature_buffer\": -140.368, \"pressure_diff_patient\": 0, \"readback_valve_air_in\": 0, \"readback_valve_o2_in\": 0, \"readback_valve_inhale\": 0, \"readback_valve_exhale\": 0, \"readback_valve_purge\": 0, \"readback_mode\": 0}, \"alarms\": null}{\"type\": \"broadcast\", \"sensors\": {\"version\": 161, \"timestamp\": 80.72, \"fsm_state\": \"IDLE\", \"pressure_air_supply\": 0, \"pressure_air_regulated\": 0, \"pressure_o2_supply\": 0, \"pressure_o2_regulated\": 0, \"pressure_buffer\": 19.731188, \"pressure_inhale\": 276.355058, \"pressure_patient\": 0, \"temperature_buffer\": -47.9, \"pressure_diff_patient\": 0, \"readback_valve_air_in\": 0, \"readback_valve_o2_in\": 0, \"readback_valve_inhale\": 0, \"readback_valve_exhale\": 0, \"readback_valve_purge\": 0, \"readback_mode\": 0}, \"alarms\": null}"`

As it's very hard to separate the blobs of JSON in a generic way without just writing a custom JSON parser. I propose appending a null byte between messages to make this easier for clients to parse. This is recommended in a few places I've checked ([example](https://forum.qt.io/topic/62083/garbage-at-the-end-of-the-document-error-on-parsing-qjsondocument/10)).