### PR TITLE
Avoid time jumps when looping over data with hevfromtxt

### DIFF
--- a/raspberry-dataserver/hevfromtxt.py
+++ b/raspberry-dataserver/hevfromtxt.py
@@ -50,7 +50,7 @@ class hevfromtxt():
                 self._pos = self._pos + self._increment
             else:
                 delay = self._timestamp[self._pos] - self._timestamp[self._pos-self._increment]
-                time_offset += self._timestamp[self._pos]
+                time_offset += self._timestamp[self._pos] - self._timestamp[0]
                 self._pos = 0
 
             time.sleep(delay)


### PR DESCRIPTION
Follow up from #24. 

When running with `python3 hevserver.py --inputFile share/sample.txt` it just jumps forward by 20.02 seconds as `share/sample.txt` doesn't start from zero. This PR fixes it.